### PR TITLE
Add Ctrl+Shift+←/→ to switch documents

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -43,6 +43,7 @@ Manage up to 9 documents
 | Key | Action |
 |-----|--------|
 | Ctrl+O | Open document picker |
+| Ctrl+Shift+←/→ | Switch to prev/next document |
 | 1-9 | Quick switch in picker |
 
 ## Leader Commands

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -329,6 +329,20 @@ fn run_app(
                         state.notification = Some(state.grid_style.name().to_string());
                     }
 
+                    // Switch to previous document
+                    (m, KeyCode::Left) if m.contains(KeyModifiers::CONTROL) && m.contains(KeyModifiers::SHIFT) => {
+                        if state.current_doc > 0 {
+                            state.switch_to(state.current_doc - 1);
+                        }
+                    }
+
+                    // Switch to next document
+                    (m, KeyCode::Right) if m.contains(KeyModifiers::CONTROL) && m.contains(KeyModifiers::SHIFT) => {
+                        if state.current_doc < state.documents.len() - 1 {
+                            state.switch_to(state.current_doc + 1);
+                        }
+                    }
+
                     // Clear document
                     (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
                         state.clear();

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -37,6 +37,7 @@ impl HelpWidget {
                 ("Ctrl+T", "Toggle task under cursor"),
                 ("Ctrl+N", "New task"),
                 ("Ctrl+O", "Open document picker"),
+                ("Ctrl+Shift+←/→", "Switch document"),
                 ("Ctrl+G", "Go to line"),
                 ("Ctrl+B", "Toggle grid style"),
                 ("Ctrl+H / F1", "Toggle help"),


### PR DESCRIPTION
## Summary
- Add keyboard shortcut `Ctrl+Shift+←/→` to quickly switch between documents
- Update help overlay and GUIDE.md with new shortcut

## Test plan
- [ ] Press `Ctrl+Shift+→` to switch to next document
- [ ] Press `Ctrl+Shift+←` to switch to previous document
- [ ] Verify help page shows new shortcut


- Closes [#9](https://github.com/siki-712/aeph/issues/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)